### PR TITLE
Set long mode active when enabled.

### DIFF
--- a/tools/uhyve-msr.h
+++ b/tools/uhyve-msr.h
@@ -7,6 +7,7 @@
 
 #define _EFER_LME		8  /* Long mode enable */
 #define EFER_LME		(1<<_EFER_LME)
+#define EFER_LMA		(1<< 10)
 
 #define MSR_IA32_APICBASE		0x0000001b
 #define MSR_IA32_MISC_ENABLE		0x000001a0

--- a/tools/uhyve.c
+++ b/tools/uhyve.c
@@ -729,7 +729,7 @@ static void filter_cpuid(struct kvm_cpuid2 *kvm_cpuid)
 static void setup_system_64bit(struct kvm_sregs *sregs)
 {
 	sregs->cr0 |= X86_CR0_PE;
-	sregs->efer |= EFER_LME;
+	sregs->efer |= EFER_LME | EFER_LMA;
 }
 
 static void setup_system_page_tables(struct kvm_sregs *sregs, uint8_t *mem)


### PR DESCRIPTION
This seems to be needed to allow things to start, at least on Ubuntu 18.04. I see similar patches to firecracker too, which makes me suspect its something needed more widely.